### PR TITLE
Fix video null exception error

### DIFF
--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -42,8 +42,42 @@ import java.math.BigDecimal;
 
 import javax.annotation.Nullable;
 
+<<<<<<< Updated upstream
+=======
+class CustomMediaController extends MediaController {
+    public CustomMediaController(Context context) {
+        super(context);
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        int keyCode = event.getKeyCode();
+        if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_MENU) {
+            Activity activity = ((ThemedReactContext) this.getContext()).getCurrentActivity();
+            if (activity != null) {
+                activity.onBackPressed();
+            }
+            return true;
+        }
+        return super.dispatchKeyEvent(event);
+    }
+}
+
+class CustomScalableVideoView extends ScalableVideoView {
+    public CustomScalableVideoView(Context context) {
+        super(context, null);
+    }
+
+    public int getCurrentPosition() {
+        if (mMediaPlayer == null) return 0;
+        return mMediaPlayer.getCurrentPosition();
+    }
+}
+
+
+>>>>>>> Stashed changes
 @SuppressLint("ViewConstructor")
-public class ReactVideoView extends ScalableVideoView implements
+public class ReactVideoView extends CustomScalableVideoView implements
     MediaPlayer.OnPreparedListener,
     MediaPlayer.OnErrorListener,
     MediaPlayer.OnBufferingUpdateListener,

--- a/android/src/main/java/com/brentvatne/react/ReactVideoView.java
+++ b/android/src/main/java/com/brentvatne/react/ReactVideoView.java
@@ -68,6 +68,7 @@ class CustomScalableVideoView extends ScalableVideoView {
         super(context, null);
     }
 
+    @Override
     public int getCurrentPosition() {
         if (mMediaPlayer == null) return 0;
         return mMediaPlayer.getCurrentPosition();


### PR DESCRIPTION
I could not repro the issue. 
But based on the logs, it throws on `ScalableVideoView.getCurrentPosition`.

I created an extended class and tested it locally everything seems to be behaving as before.
One confusing thing for me is that `ScalableVideoView` has multiple constructors, not sure if I extended the constructor correctly, let me know.

[Thread on tarobi](https://www.tarobi-dev-test.com/guilded-dev/groups/EdxXXvjd/channels/07761c1b-db84-4a4b-8e28-2f9d66311d29/list?listItemId=7b785a53-6e26-446c-8e46-639d4655fa78)